### PR TITLE
extract and then map

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ A gif of surface temperatures for 185,549 lakes using data from [Willard et al. 
 
 
 ## Build the gif
-This gif is created using a pipeline with the `targets` library for R. To run the pipeline run `tar_make()` in the console. The final gif is created using system calls to [`magick`](https://imagemagick.org/index.php) and [`gifsicle`](https://www.lcdf.org/gifsicle/), and will require that they are installed on your computer to work.
+This gif is created using a pipeline with the `targets` library for R. It takes approximately 3 hours to build the gif.
+
+To run the pipeline run `tar_make()` in the console. The final gif is created using system calls to [`magick`](https://imagemagick.org/index.php) and [`gifsicle`](https://www.lcdf.org/gifsicle/), and will require that they are installed on your computer to work.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lake-temp-timeseries
-A gif of surface temperatures for 185,549 lakes. For this pipeline to work you must download all files from https://doi.org/10.5066/P9CEMS0M and place in a subdirectory, `in/`. 
+A gif of surface temperatures for 185,549 lakes using data from [Willard et al. 2022](https://aslopubs.onlinelibrary.wiley.com/doi/10.1002/lol2.10249). The [data are sourced from ScienceBase](https://doi.org/10.5066/P9CEMS0M) using the [`sbtools`](https://github.com/USGS-R/sbtools) package for R, and placed in a subdirectory, `in/`. 
 
 
 ## Build the gif

--- a/_targets.R
+++ b/_targets.R
@@ -21,15 +21,15 @@ proj <- '+proj=lcc +lat_1=30.7 +lat_2=29.3 +lat_0=28.5 +lon_0=-91.33333333333333
 list(
   # this assumes you downloaded all files from https://doi.org/10.5066/P9CEMS0M 
   tar_target(
+    lake_files,
+    download_sb_files(sb_id = "60341c3ed34eb12031172aa6", 
+                      file_string = "predicted_temp", 
+                      dest_folder = "in")
+  ),
+  tar_target(
     all_metadata, 
     read_csv(file.path('in/lake_metadata.csv'))
     ),
-  tar_target(
-    lake_files, # CONUS is chunked
-    all_metadata %>% 
-      mutate(filepath = file.path(sprintf("in/%s_predicted_temp_%s.nc", group_id, group_bbox))) %>%
-      pull(filepath) %>% unique()
-  ),
   tar_target(
     date_list, 
     seq.Date(

--- a/_targets.R
+++ b/_targets.R
@@ -28,7 +28,7 @@ list(
     format = "file"
   ),
   tar_target(
-    date_list, 
+    date_df, 
     tibble(date = seq.Date(
       as.Date(sprintf('%s-%s', year_start, day_start)), 
       as.Date(sprintf('%s-%s', year_end, day_end)), by = "days"),
@@ -36,12 +36,12 @@ list(
   ),
   tar_target(
     temp_data, # pulls all data at once, may want to split if > 1 yr
-    get_temp_data(date_list$date, lake_files)
+    get_temp_data(date_df$date, lake_files)
   ),
   tar_target(
     temp_daily, # split data by date
-    get_daily_temps(temp_data, date_list, proj),
-    pattern = map(date_list)
+    get_daily_temps(temp_data, date_df, proj),
+    pattern = map(date_df)
   ),
   tar_target(
     usa_sf, 
@@ -50,11 +50,11 @@ list(
   tar_target(
     lake_temp_pngs, # create frames
     plot_lake_temp(temp_daily, 
-                   time = date_list$date,
+                   time = date_df$date,
                    usa_sf,
-                   file_out = sprintf('out/lake_temp_%s.png', date_list$order),
+                   file_out = sprintf('out/lake_temp_%s.png', date_df$order),
                    pal = "mako"),
-    pattern = map(temp_daily, date_list),
+    pattern = map(temp_daily, date_df),
     format = "file"
   ),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -1,4 +1,5 @@
 library(targets)
+library(sbtools)
 library(tidyverse)
 library(ncdf4)
 library(sf)
@@ -19,22 +20,27 @@ year_end <- '2020'
 proj <- '+proj=lcc +lat_1=30.7 +lat_2=29.3 +lat_0=28.5 +lon_0=-91.33333333333333 +x_0=999999.9999898402 +y_0=0 +ellps=GRS80 +datum=NAD83 +to_meter=0.3048006096012192 +no_defs'
 
 list(
-  # this assumes you downloaded all files from https://doi.org/10.5066/P9CEMS0M 
   tar_target(
-    lake_files,
+    lake_files, # download files from https://doi.org/10.5066/P9CEMS0M 
     download_sb_files(sb_id = "60341c3ed34eb12031172aa6", 
                       file_string = "predicted_temp", 
-                      dest_folder = "in")
+                      dest_folder = "in"),
+    format = "file"
   ),
   tar_target(
     date_list, 
-    seq.Date(
+    tibble(date = seq.Date(
       as.Date(sprintf('%s-%s', year_start, day_start)), 
-      as.Date(sprintf('%s-%s', year_end, day_end)), by = "days")
+      as.Date(sprintf('%s-%s', year_end, day_end)), by = "days"),
+      order = seq(1, length(date)))
   ),
   tar_target(
-    temp_data, # find temp for all lakes on a given day
-    get_daily_temp(date = date_list, lake_files),
+    temp_data, # pulls all data at once, may want to split if > 1 yr
+    get_temp_data(date_list$date, lake_files)
+  ),
+  tar_target(
+    temp_daily, # split data by date
+    get_daily_temps(temp_data, date_list, proj),
     pattern = map(date_list)
   ),
   tar_target(
@@ -43,12 +49,12 @@ list(
   ),
   tar_target(
     lake_temp_pngs, # create frames
-    plot_lake_temp(temp_data, 
-                   time = date_list,
+    plot_lake_temp(temp_daily, 
+                   time = date_list$date,
                    usa_sf,
-                   file_out = sprintf('out/lake_temp_%s.png', date_list),
+                   file_out = sprintf('out/lake_temp_%s.png', date_list$order),
                    pal = "mako"),
-    pattern = map(temp_data, date_list),
+    pattern = map(temp_daily, date_list),
     format = "file"
   ),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -27,10 +27,6 @@ list(
                       dest_folder = "in")
   ),
   tar_target(
-    all_metadata, 
-    read_csv(file.path('in/lake_metadata.csv'))
-    ),
-  tar_target(
     date_list, 
     seq.Date(
       as.Date(sprintf('%s-%s', year_start, day_start)), 

--- a/src/data_utils.R
+++ b/src/data_utils.R
@@ -1,5 +1,7 @@
 download_sb_files <- function(sb_id, file_string, dest_folder) {
   
+  if(!dir.exists(dest_folder)) dir.create(dest_folder)
+  
   sb_filenames <- item_list_files(sb_id)
   sb_files <- sb_filenames %>% filter(str_detect(fname, file_string))
   local_files <- file.path(dest_folder, sb_files$fname)

--- a/src/data_utils.R
+++ b/src/data_utils.R
@@ -1,3 +1,20 @@
+download_sb_files <- function(sb_id, file_string, dest_folder) {
+  
+  sb_filenames <- item_list_files(sb_id)
+  sb_files <- sb_filenames %>% filter(str_detect(fname, file_string))
+  local_files <- file.path(dest_folder, sb_files$fname)
+  
+  if(any(!file.exists(local_files))){
+    item_file_download(
+      sb_id, 
+      names = sb_files$fname, 
+      destinations = local_files,
+      overwrite_file = FALSE)
+  }
+  
+  return(local_files)
+  
+}
 get_daily_temp <- function(date, lake_files){
   
   # predicted temp for all lakes at once

--- a/src/data_utils.R
+++ b/src/data_utils.R
@@ -15,26 +15,6 @@ download_sb_files <- function(sb_id, file_string, dest_folder) {
   return(local_files)
   
 }
-get_daily_temp <- function(date, lake_files){
-  
-  # predicted temp for all lakes at once
-  plot_data <- purrr::map(lake_files, function(lake_file){
-    nc <- nc_open(lake_file)
-    
-    time_origin <- ncdf4::ncatt_get(nc, 'time', attname = 'units')$value %>% str_remove("days since ")
-    time <- ncvar_get(nc, 'time') + as.Date(time_origin)
-    time_idx <- which(time == date)
-  
-    all_surftemp <- ncvar_get(nc, 'surftemp', start = c(time_idx, 1), count = c(1, -1))
-    lake_lat <-  ncvar_get(nc, 'lat')
-    lake_lon <-  ncvar_get(nc, 'lon')
-    lake_id <-  ncvar_get(nc, 'site_id')
-    nc_close(nc)
-    tibble(surftemp = all_surftemp, lat = lake_lat, lon = lake_lon, site_id = lake_id)
-  }) %>% bind_rows() %>% 
-    st_as_sf(coords = c("lon", "lat"), crs = 4326) %>% 
-    st_transform(proj)  
-}
 get_temp_data <- function(date_list, lake_files){
   
   # predicted temp for all lakes at once

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -57,45 +57,6 @@ plot_lake_temp <- function(temp_data, time, usa_sf, file_out, pal){
   ggsave(file_out, width = 10*dpi, height = 7.15*dpi, units = 'px', dpi = dpi)
 }
 
-plot_lake_temp_all <- function(temp_data, date_list, usa_sf, file_out, pal){
-  plot_data <- test_data$temp
-  plot_data  
-  
-  ggplot() +
-    geom_sf(data = usa_sf,
-            fill = "white",
-            color = "grey" 
-    ) +
-    geom_sf(data = temp_data, 
-            size = 0.2, 
-            aes(color = surftemp)
-    ) + 
-    scale_color_viridis_c(
-      option = pal,
-      limits = c(0, 35),
-      "Degrees (C)"
-    ) +
-    theme_lakes()  +
-    coord_sf(label_axes = list(bottom = "E", right = "N")) +
-    ggtitle("Surface temperatures for 185,549 lakes",
-            subtitle = sprintf("%s", time)) +
-    guides(color = guide_colorbar(
-      direction = "horizontal",
-      barwidth = 14, 
-      barheight =  0.8,
-      label.position = "bottom",
-      title.position = "top",
-      title.theme = element_text(family = "Source Sans Pro", 
-                                 #face = "bold", 
-                                 size = 20, 
-                                 lineheight = 0.7
-      )
-    ))
-  
-  dpi <- 90
-  ggsave(file_out, width = 10*dpi, height = 7.15*dpi, units = 'px', dpi = dpi)
-}
-
 combine_animation_frames_gif <- function(out_file, frame_delay_cs, frame_rate) {
   # modified from https://github.com/USGS-VIZLAB/gage-conditions-gif/blob/main/6_visualize/src/combine_animation_frames.R
   

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -57,6 +57,45 @@ plot_lake_temp <- function(temp_data, time, usa_sf, file_out, pal){
   ggsave(file_out, width = 10*dpi, height = 7.15*dpi, units = 'px', dpi = dpi)
 }
 
+plot_lake_temp_all <- function(temp_data, date_list, usa_sf, file_out, pal){
+  plot_data <- test_data$temp
+  plot_data  
+  
+  ggplot() +
+    geom_sf(data = usa_sf,
+            fill = "white",
+            color = "grey" 
+    ) +
+    geom_sf(data = temp_data, 
+            size = 0.2, 
+            aes(color = surftemp)
+    ) + 
+    scale_color_viridis_c(
+      option = pal,
+      limits = c(0, 35),
+      "Degrees (C)"
+    ) +
+    theme_lakes()  +
+    coord_sf(label_axes = list(bottom = "E", right = "N")) +
+    ggtitle("Surface temperatures for 185,549 lakes",
+            subtitle = sprintf("%s", time)) +
+    guides(color = guide_colorbar(
+      direction = "horizontal",
+      barwidth = 14, 
+      barheight =  0.8,
+      label.position = "bottom",
+      title.position = "top",
+      title.theme = element_text(family = "Source Sans Pro", 
+                                 #face = "bold", 
+                                 size = 20, 
+                                 lineheight = 0.7
+      )
+    ))
+  
+  dpi <- 90
+  ggsave(file_out, width = 10*dpi, height = 7.15*dpi, units = 'px', dpi = dpi)
+}
+
 combine_animation_frames_gif <- function(out_file, frame_delay_cs, frame_rate) {
   # modified from https://github.com/USGS-VIZLAB/gage-conditions-gif/blob/main/6_visualize/src/combine_animation_frames.R
   


### PR DESCRIPTION
To address https://github.com/USGS-VIZLAB/lake-temp-timeseries/issues/2 and unresolved feedback from [the prior PR](https://github.com/USGS-VIZLAB/lake-temp-timeseries/pull/1), I've:
- added a target to download data files directly from ScienceBase
- updated the README
- modified function that reads the data to extract data for all days in one move, and then
- added a target that uses dynamic branching to split the data by date

While working with the netCDF is much more efficient, the added step to branch the data by date is slow. I'm not sure if this is the best way to do that, but I wanted to keep the data branching separate from the plotting to make it easier to edit and rebuild the pngs.