### PR TITLE
Use magick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out/*.png
 out/*.gif
 tmp/*.png
 src/scratch.R
+*png

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ A gif of surface temperatures for 185,549 lakes using data from [Willard et al. 
 ## Build the gif
 This gif is created using a pipeline with the `targets` library for R. It takes approximately 3 hours to build the gif. 
 
-To run the pipeline run `tar_make()` in the console. The final gif is created using the [`magick package`](https://github.com/ropensci/magick) and a system call to [`gifsicle`](https://www.lcdf.org/gifsicle/) to reduce the file size. You will need to install [`gifsicle`](https://www.lcdf.org/gifsicle/) on your computer to procude the final gif. If you would like to skip the final optimization step via `gifsicle`, modify the `lake_temp_2020_gif` target call to `reduce = FALSE`.
+To run the pipeline run `tar_make()` in the console. The final gif is created using the [`magick package`](https://github.com/ropensci/magick) and a system call to [`gifsicle`](https://www.lcdf.org/gifsicle/) to reduce the file size. You will need to install [`gifsicle`](https://www.lcdf.org/gifsicle/) on your computer to produce the final gif. If you would like to skip the final optimization step via `gifsicle`, modify the `lake_temp_2020_gif` target call to `reduce = FALSE`.
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A gif of surface temperatures for 185,549 lakes using data from [Willard et al. 
 
 
 ## Build the gif
-This gif is created using a pipeline with the `targets` library for R. To run the pipeline run `tar_make()` in the console. The final gif is created using system calls to [`magick`](https://imagemagick.org/index.php) and [`gifsicle`](https://www.lcdf.org/gifsicle/), and will require that they are installed on your computer to work.
+This gif is created using a pipeline with the `targets` library for R. To run the pipeline run `tar_make()` in the console. The final gif is created using the [`magick package`](https://github.com/ropensci/magick) and a system call to [`gifsicle`](https://www.lcdf.org/gifsicle/) to reduce the file size. You will need to install [`gifsicle`](https://www.lcdf.org/gifsicle/) on your computer to procude the final gif. If you would like to skip the final optimization step via `gifsicle`, modify the `lake_temp_2020_gif` target call to `reduce = FALSE`.

--- a/_targets.R
+++ b/_targets.R
@@ -58,9 +58,19 @@ list(
     format = "file"
   ),
   tar_target(
+    scaled_pngs,
+    resize_frames(frames = lake_temp_pngs, 
+                  scale_width = 900, # px
+                  dir_out = 'tmp/scaled'
+                  ),
+    format = 'file'
+  ),
+  tar_target(
     lake_temp_2020_gif, # animate frames
     combine_animation_frames_gif(
-      out_file = 'out/lake_temp_2020.gif',
+      frames = scaled_pngs,
+      frames_dir = 'tmp/scaled',
+      out_file = 'out/lake_temp_2020_scaled.gif',
       frame_delay_cs = 14, 
       frame_rate = 60
     ),

--- a/_targets.R
+++ b/_targets.R
@@ -70,6 +70,7 @@ list(
     animate_frames_gif(
       frames = scaled_pngs,
       out_file = 'out/lake_temp_2020.gif',
+      reduce = TRUE,
       frame_delay_cs = 10,
       frame_rate = 60
     ),

--- a/_targets.R
+++ b/_targets.R
@@ -66,14 +66,13 @@ list(
     format = 'file'
   ),
   tar_target(
-    lake_temp_2020_gif, # animate frames
-    combine_animation_frames_gif(
+    lake_temp_2020_gif,
+    animate_frames_gif(
       frames = scaled_pngs,
-      frames_dir = 'tmp/scaled',
-      out_file = 'out/lake_temp_2020_scaled.gif',
-      frame_delay_cs = 14, 
+      out_file = 'out/lake_temp_2020.gif',
+      frame_delay_cs = 10,
       frame_rate = 60
     ),
-    format = "file"
+    format = 'file'
   )
 )

--- a/src/data_utils.R
+++ b/src/data_utils.R
@@ -35,6 +35,7 @@ get_temp_data <- function(date_list, lake_files){
     lake_data <- ncvar_get(nc, 'surftemp', 
                            start = c(first(time_idx), 1), 
                            count = c(last(time_idx) - first(time_idx) + 1, -1))
+    nc_close(nc)
  
     tibble(
       site_id = lake_id,

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -78,9 +78,7 @@ resize_frames <- function(frames, scale_width, scale_percent = NULL, dir_out) {
   map2(as.list(frames_scaled), png_names, ~image_write(.x, .y))
   
   return(png_names)
-  
-  ## ideally each frame is under 400 KB
-  
+
   #  image_animate(
     #    delay = frame_delay_cs,
     #    optimize = TRUE,
@@ -88,21 +86,19 @@ resize_frames <- function(frames, scale_width, scale_percent = NULL, dir_out) {
     #  ) %>%
     #  image_write(out_file)
 }
-combine_animation_frames_gif <- function(frames, frames_dir, out_file, frame_delay_cs, frame_rate) {
-  # modified from https://github.com/USGS-VIZLAB/gage-conditions-gif/blob/main/6_visualize/src/combine_animation_frames.R
-  #png_files <- list.files(frames_dir, pattern = "*.png", full.names = TRUE)
-  png_str <- paste(frames, collapse=' ')
+animate_frames_gif <- function(frames, out_file, frame_delay_cs, frame_rate){
+  frames %>%
+    image_read() %>%
+    image_join() %>%
+    image_animate(
+      delay = frame_delay_cs,
+      optimize = TRUE,
+      fps = frame_rate
+    ) %>%
+    image_write(out_file)
+}
+optimize_gif <- function(frames, frames_dir, out_file, frame_delay_cs, frame_rate) {
 
-  # create gif using magick
-  magick_command <- sprintf(
-    'convert -define registry:temporary-path=%s -limit memory 24GiB -delay %d -loop 0 %s %s',
-    frames_dir, frame_delay_cs, png_str, out_file)
-  if(Sys.info()[['sysname']] == "Windows") {
-    magick_command <- sprintf('magick %s', magick_command)
-  }
-  system(magick_command)
-
-  
   # simplify the gif with gifsicle - cuts size by about 2/3
   gifsicle_command <- sprintf('gifsicle -b -O3 -d %s %s',
                               frame_delay_cs, out_file)

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -79,14 +79,8 @@ resize_frames <- function(frames, scale_width, scale_percent = NULL, dir_out) {
   
   return(png_names)
 
-  #  image_animate(
-    #    delay = frame_delay_cs,
-    #    optimize = TRUE,
-    #    fps = frame_rate
-    #  ) %>%
-    #  image_write(out_file)
 }
-animate_frames_gif <- function(frames, out_file, frame_delay_cs, frame_rate){
+animate_frames_gif <- function(frames, out_file, reduce = TRUE, frame_delay_cs, frame_rate){
   frames %>%
     image_read() %>%
     image_join() %>%
@@ -96,11 +90,18 @@ animate_frames_gif <- function(frames, out_file, frame_delay_cs, frame_rate){
       fps = frame_rate
     ) %>%
     image_write(out_file)
+  
+  if(reduce == TRUE){
+    optimize_gif(out_file, frame_delay_cs)
+  }
+  
+  return(out_file)
+  
 }
-optimize_gif <- function(frames, frames_dir, out_file, frame_delay_cs, frame_rate) {
+optimize_gif <- function(out_file, frame_delay_cs) {
 
   # simplify the gif with gifsicle - cuts size by about 2/3
-  gifsicle_command <- sprintf('gifsicle -b -O3 -d %s %s',
+  gifsicle_command <- sprintf('gifsicle -b -O3 -d %s --colors 256 %s',
                               frame_delay_cs, out_file)
   system(gifsicle_command)
   


### PR DESCRIPTION
This reworks the gif generation in the interest of making it a little more public-friendly. I've:
- replaced the system call to `Image Magick` with the R `magick` package
- added an option to omit the optimization step via `gifsicle` via `reduce = FALSE` on the `lake_temp_2020_gif` target

I also reworked the gif steps so that frames get resized in a step separate to building the gif. This is pretty efficient, although I am repeating some `magick` steps when doing this. I think this is ok, because it makes it easier to evaluate the impact of the resize. With this gif in particular I struggled to get the file size down, so having this step separate allows for easier troubleshooting. 